### PR TITLE
Rangement des --no-check-certificate

### DIFF
--- a/install/auto_install_geopoppy.sh
+++ b/install/auto_install_geopoppy.sh
@@ -1,14 +1,14 @@
 #!/bin/sh 
 #
 # Commande d'installation
-### wget --no-check-certificate -P /home/pirate wget https://raw.githubusercontent.com/jancelin/geo--no-check-certificate -Poppy/master/install/auto_install_geopoppy.sh; chmod +x /home/pirate/auto_install_geopoppy.sh; sh /home/pirate/auto_install_geopoppy.sh
+### wget --no-check-certificate -P /home/pirate wget https://raw.githubusercontent.com/jancelin/geoppy/master/install/auto_install_geopoppy.sh; chmod +x /home/pirate/auto_install_geopoppy.sh; sh /home/pirate/auto_install_geopoppy.sh
 
 wget --no-check-certificate -P /home/pirate https://raw.githubusercontent.com/jancelin/rpi_wifi_direct/master/raspberry_pi3/install_wifi_direct_rpi3.sh; chmod +x /home/pirate/install_wifi_direct_rpi3.sh; bash -x /home/pirate/install_wifi_direct_rpi3.sh &&
 mkdir /home/pi &&
-wget --no-check-certificate -P /home/pi https://github.com/jancelin/geo--no-check-certificate -Poppy/raw/master/install/geopoppy_sig.tar &&
-wget --no-check-certificate -P /home/pi https://github.com/jancelin/geo--no-check-certificate -Poppy/raw/master/install/geopoppy_base.tar &&
-tar xvfz /home/pi/geopoppy_sig.tar ---no-check-certificate -Preserve --same-owner -C /  &&
-tar xvfz /home/pi/geopoppy_base.tar ---no-check-certificate -Preserve --same-owner -C /  &&
+wget --no-check-certificate -P /home/pi https://github.com/jancelin/geo-poppy/raw/master/install/geopoppy_sig.tar &&
+wget --no-check-certificate -P /home/pi https://github.com/jancelin/geo-poppy/raw/master/install/geopoppy_base.tar &&
+tar xvfz /home/pi/geopoppy_sig.tar --preserve --same-owner -C /  &&
+tar xvfz /home/pi/geopoppy_base.tar --preserve --same-owner -C /  &&
 cp /home/GeoPoppy/docker-compose.yml /home/pirate/ &&
 docker-compose up -d &&
 sleep 5
@@ -23,12 +23,12 @@ echo "* Connection Data Base avec PgAdminIII ou Qgis sur la même ip, port 5432,
 echo "* Construire ses projets Qgis dans le répertoire /home/GeoPoppy/lizmap/project pour les rendre accessibles"
 echo " "
 echo "Julien ANCELIN "
-echo "https://github.com/jancelin/geo--no-check-certificate -Poppy"
+echo "https://github.com/jancelin/geooppy"
 
 ###_____________________________________________________________________________
 ## Commande de sauvegarde du dossier data
 ## tar zcvf /home/pi/geopoppy.tar /home/GeoPoppy
 
 ### Commande de restauration du dossier data
-## tar xvfz /home/pi/geopoppy.tar ---no-check-certificate -Preserve --same-owner -C /
+## tar xvfz /home/pi/geopoppy.tar --preserve --same-owner -C /
 #___________________________________________________________________


### PR DESCRIPTION
À nouveau, je propose de les organiser autrement (avant le -P).
Petit doute sur le "--preserve", il me semble que c'est bien ça mais ça vaut le coup de faire une relecture.
