### PR TITLE
Speed up rendering : enable parallel rendering

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
     environment:
       PGSERVICEFILE: /srv/etc/pg_service.conf
       QGSRV_CACHE_ROOTDIR: /srv/projects
+      QGSRV_SERVER_PARALLEL_RENDERING: '1'
       QGSRV_SERVER_WORKERS: 4
       QGSRV_CACHE_SIZE: '20'
       QGSRV_LOGGING_LEVEL: DEBUG


### PR DESCRIPTION
Parallel rendering is disable by default. Rendering geopoppy 2 project is realy slow without this option.

```
QGIS_SERVER_PARALLEL_RENDERING

Activates parallel rendering for WMS GetMap requests. It’s disabled (false) by default. Available values are:

0 or false (case insensitive)
1 or true (case insensitive)
```


https://docs.qgis.org/3.4/en/docs/user_manual/working_with_ogc/server/config.html#qgis-server-parallel-rendering